### PR TITLE
Improve login and edit modals

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -108,6 +108,10 @@
         setEditContent(post.content);
       };
 
+      const cancelEdit = () => {
+        setEditingId(null);
+      };
+
       const saveEdit = id => {
         fetch(`/api/posts/${id}`, {
           method: 'PUT',
@@ -148,8 +152,15 @@
             )}
           </div>
           {showLogin && !token && (
-            <div className="modal-overlay">
-              <div className="modal-dialog">
+            <div
+              className="modal-overlay"
+              onClick={() => {
+                setShowLogin(false);
+                setIsSignUp(false);
+                resetAuthForm();
+              }}
+            >
+              <div className="modal-dialog" onClick={e => e.stopPropagation()}>
                 <div className="modal-content position-relative p-4">
                   <button
                     type="button"
@@ -241,6 +252,44 @@
               </div>
             </div>
           )}
+          {editingId && (
+            <div
+              className="modal-overlay"
+              onClick={cancelEdit}
+            >
+              <div className="modal-dialog" onClick={e => e.stopPropagation()}>
+                <div className="modal-content position-relative p-4">
+                  <button
+                    type="button"
+                    className="btn-close position-absolute top-0 end-0 m-2"
+                    onClick={cancelEdit}
+                  ></button>
+                  <h5 className="mb-3">Edit Post</h5>
+                  <input
+                    className="form-control mb-2"
+                    value={editTitle}
+                    onChange={e => setEditTitle(e.target.value)}
+                  />
+                  <textarea
+                    className="form-control mb-3"
+                    value={editContent}
+                    onChange={e => setEditContent(e.target.value)}
+                  />
+                  <div className="d-flex justify-content-end">
+                    <button
+                      className="btn btn-primary me-2"
+                      onClick={() => saveEdit(editingId)}
+                    >
+                      Save
+                    </button>
+                    <button className="btn btn-secondary" onClick={cancelEdit}>
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
           {token && (
             <form onSubmit={createPost} className="mb-4">
               <h5>Create Post</h5>
@@ -265,61 +314,37 @@
           {posts.map(post => (
             <div key={post._id || post.link} className="card mb-3">
               <div className="card-body">
-		{editingId === post._id ? (
-                  <React.Fragment>
-                    <input
-                      className="form-control mb-2"
-                      value={editTitle}
-                      onChange={e => setEditTitle(e.target.value)}
-                    />
-                    <textarea
-                      className="form-control mb-2"
-                      value={editContent}
-                      onChange={e => setEditContent(e.target.value)}
-                    />
+                <h5 className="card-title">
+                  <a href={post.link} target="_blank" rel="noopener">
+                    {post.title}
+                  </a>
+                </h5>
+                <p className="card-text">{post.contentSnippet}</p>
+                <p className="card-text">
+                  <small className="text-muted">
+                    {
+                      (() => {
+                        const d = new Date(post.pubDate);
+                        return isNaN(d) ? '' : d.toLocaleString();
+                      })()
+                    }
+                  </small>
+                </p>
+                {token && (
+                  <div>
                     <button
-                      className="btn btn-primary btn-sm me-2"
-                      onClick={() => saveEdit(post._id)}
+                      className="btn btn-sm btn-outline-primary me-2"
+                      onClick={() => startEdit(post)}
                     >
-                      Save
+                      Edit
                     </button>
                     <button
-                      className="btn btn-secondary btn-sm"
-                      onClick={() => setEditingId(null)}
+                      className="btn btn-sm btn-outline-danger"
+                      onClick={() => deletePost(post._id)}
                     >
-                      Cancel
+                      Delete
                     </button>
-                  </React.Fragment>
-                ) : (
-                  <React.Fragment>
-                    <h5 className="card-title">
-                      <a href={post.link} target="_blank" rel="noopener">
-                        {post.title}
-                      </a>
-                    </h5>
-                    <p className="card-text">{post.contentSnippet}</p>
-                    <p className="card-text">
-                      <small className="text-muted">
-                        {new Date(post.pubDate).toLocaleString()}
-                      </small>
-                    </p>
-                    {token && (
-                      <div>
-                        <button
-                          className="btn btn-sm btn-outline-primary me-2"
-                          onClick={() => startEdit(post)}
-                        >
-                          Edit
-                        </button>
-                        <button
-                          className="btn btn-sm btn-outline-danger"
-                          onClick={() => deletePost(post._id)}
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    )}
-                  </React.Fragment>
+                  </div>
                 )}
               </div>
             </div>

--- a/client/style.css
+++ b/client/style.css
@@ -38,3 +38,8 @@ h1 {
   width: 100%;
   max-width: 400px;
 }
+
+.modal-content .btn-close {
+  width: 1.5rem;
+  height: 1.5rem;
+}

--- a/server/server.js
+++ b/server/server.js
@@ -108,7 +108,7 @@ app.post('/api/posts', auth, async (req, res) => {
       link: '#',
       content,
       contentSnippet: content,
-      pubDate: new Date()
+      pubDate: new Date().toISOString()
     };
     if (useMemory) {
       Post.unshift(newPost);


### PR DESCRIPTION
## Summary
- enlarge the login modal close button and allow clicking the overlay to close
- display edit form in a popup modal
- ensure date is rendered correctly and store new posts with ISO timestamps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851e3bb7350832c92d09bcef48f932e