### PR TITLE
UI layout adjustments

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -137,7 +137,7 @@
 
       return (
         <div className="container my-5">
-          <div className="d-flex justify-content-end mb-3">
+        <div className="login-container d-flex justify-content-end mb-3">
             {token ? (
               <button className="btn btn-outline-secondary" onClick={logout}>
                 Logout
@@ -259,7 +259,7 @@
               className="modal-overlay"
               onClick={cancelEdit}
             >
-              <div className="modal-dialog" onClick={e => e.stopPropagation()}>
+              <div className="modal-dialog edit-dialog" onClick={e => e.stopPropagation()}>
                 <div className="modal-content position-relative p-4">
                   <button
                     type="button"
@@ -317,7 +317,7 @@
           )}
           <h1 className="mb-4 text-center">RSS Blog</h1>
           {posts.map(post => (
-            <div key={post._id || post.link} className="card mb-3">
+            <div key={post._id || post.link} className="card mb-3 post-card">
               <div className="card-body">
                 <h5 className="card-title">
                   <a href={post.link} target="_blank" rel="noopener">

--- a/client/style.css
+++ b/client/style.css
@@ -8,8 +8,22 @@ h1 {
   text-align: center;
 }
 
+.login-container {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 1100;
+}
+
 .card + .card {
   margin-top: 1rem;
+}
+
+.post-card {
+  width: 75%;
+  max-width: 800px;
+  margin: 0 auto 1rem;
+  min-height: 20vh;
 }
 
 .card-title a {
@@ -37,6 +51,11 @@ h1 {
 .modal-dialog {
   width: 100%;
   max-width: 400px;
+}
+
+.edit-dialog {
+  width: 90%;
+  max-width: 600px;
 }
 
 .modal-content .btn-close {


### PR DESCRIPTION
## Summary
- reposition login button to top-right corner
- boxify posts for consistent sizing
- widen edit modal

## Testing
- `npm install`
- `npm start` *(fails: warnings only)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851f58203dc832c8d460a0040b26102