### PR TITLE
Fix date display and add infinite scroll

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -28,6 +28,7 @@
       const [confirmPassword, setConfirmPassword] = useState('');
       const [showManage, setShowManage] = useState(false);
       const [newFeed, setNewFeed] = useState('');
+      const [visibleCount, setVisibleCount] = useState(10);
 
       useEffect(() => {
         if (token) {
@@ -61,10 +62,22 @@
           )
         ).then(results => {
           const all = results.flat();
-          all.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
+          all.sort((a, b) => new Date(b.isoDate || b.pubDate) - new Date(a.isoDate || a.pubDate));
           setPosts(all);
+          setVisibleCount(10);
         });
+
       }, [feeds]);
+      useEffect(() => {
+        const handleScroll = () => {
+          if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 100) {
+            setVisibleCount(v => Math.min(posts.length, v + 10));
+          }
+        };
+        window.addEventListener("scroll", handleScroll);
+        return () => window.removeEventListener("scroll", handleScroll);
+      }, [posts]);
+
 
       const resetAuthForm = () => {
         setUsername('');
@@ -210,12 +223,12 @@
               Failed to load {err.url} (status {err.status})
             </div>
           ))}
-          {posts.map(post => (
+          {posts.slice(0, visibleCount).map(post => (
             <div key={post.link} className="card mb-3 post-card">
               <div className="card-body">
                 <h5 className="card-title"><a href={post.link} target="_blank" rel="noopener">{post.title}</a></h5>
                 <p className="card-text">{post.contentSnippet}</p>
-                <p className="card-text"><small className="text-muted">{(() => { const d = new Date(post.pubDate); return isNaN(d) ? '' : d.toLocaleString(); })()}</small></p>
+                <p className="card-text"><small className="text-muted">{(() => { const d = new Date(post.isoDate || post.pubDate); return isNaN(d) ? '' : d.toLocaleString(); })()}</small></p>
                 <p className="card-text"><small className="text-muted">{post.feedUrl}</small></p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- use `isoDate` when available to sort and display RSS items
- reset and track how many posts are visible
- add scroll handler to load 10 more posts when reaching the bottom
- slice posts array when rendering

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68530cc4ab88832cae781b7676b4c35e